### PR TITLE
Use a fixed packet for ntpv5.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,24 @@ impl From<NtpPacket<'_>> for Request {
     }
 }
 
+impl From<&[u8]> for Request {
+    fn from(value: &[u8]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<const N: usize> From<[u8;N]> for Request {
+    fn from(value: [u8;N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<const N: usize> From<&[u8;N]> for Request {
+    fn from(value: &[u8;N]) -> Self {
+        Self(value.into())
+    }
+}
+
 #[derive(Clone)]
 pub struct Response(pub Vec<u8>);
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -58,8 +58,7 @@ pub fn test_responds_to_version_4(conn: &mut Connection) -> anyhow::Result<TestR
 /// Since NTPv5 is not released yet any compliant server should still ignore
 /// packets with this version number.
 pub fn test_ignores_version_5(conn: &mut Connection) -> anyhow::Result<TestResult> {
-    let (packet, _id) = NtpPacket::poll_message_v5(Default::default());
-    let response = conn.pester(packet)?;
+    let response = conn.pester(b"\x2B\x02\x06\xe9\x00\x00\x02\x36\x00\x00\x03\xb7\xc0\x35\x67\x6c\xe5\xf6\x61\xfd\x6f\x16\x5f\x03\xe5\xf6\x63\xa8\x76\x19\xef\x40\xe5\xf6\x63\xa8\x79\x8c\x65\x81\xe5\xf6\x63\xa8\x79\x8e\xae\x2b")?;
 
     pester_assert_no_response!(response, "Should not respond to ntp version 5 requests");
 


### PR DESCRIPTION
This ensures we always send just a header.